### PR TITLE
Add elf option to cargo-flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `--speed` setting to configure protocol speed in kHz.
-
 ### Changed
 
 ### Fixed
@@ -20,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `--speed` setting to configure protocol speed in kHz.
 - Upgrade to probe-rs 0.6.0 which fixes some bugs that appeared within cargo-flash (see [CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md))
 - Add a `--restore-unwritten` flag which makes the flashing procedure restore all bytes that have been erased in the sectore erase but are not actually in the writeable sections of the ELF data.
+- Add an `--elf` setting to point to a specific ELF binary instead of a cargo one.
+- Add a `--work-dir` for cargo flash to operate in.
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,6 @@ dependencies = [
 [[package]]
 name = "gdb-server"
 version = "0.6.0"
-source = "git+https://github.com/probe-rs/probe-rs/#b23383f6d87fd5c89fcd422404dd8393ad67b3ad"
 dependencies = [
  "async-std",
  "futures",
@@ -957,7 +956,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "probe-rs"
 version = "0.6.0"
-source = "git+https://github.com/probe-rs/probe-rs/#b23383f6d87fd5c89fcd422404dd8393ad67b3ad"
 dependencies = [
  "base64",
  "bitfield",
@@ -985,7 +983,6 @@ dependencies = [
 [[package]]
 name = "probe-rs-t2rust"
 version = "0.6.0"
-source = "git+https://github.com/probe-rs/probe-rs/#b23383f6d87fd5c89fcd422404dd8393ad67b3ad"
 dependencies = [
  "base64",
  "proc-macro2 1.0.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,3 @@ lazy_static = "1.4.0"
 colored = "1.8.3"
 probe-rs = { version = "0.6.0" }
 gdb-server = { version = "0.6.0" }
-
-[patch.crates-io]
-probe-rs = { git = "https://github.com/probe-rs/probe-rs/" }
-gdb-server = { git = "https://github.com/probe-rs/probe-rs/" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,12 @@ struct Opt {
         help = "The path to the ELF file to be flashed."
     )]
     elf: Option<String>,
+    #[structopt(
+        name = "directory",
+        long = "work-dir",
+        help = "The work directory from which cargo-flash should operate from."
+    )]
+    work_dir: Option<String>,
 
     // `cargo build` arguments
     #[structopt(name = "binary", long = "bin")]
@@ -122,6 +128,7 @@ const ARGUMENTS_TO_REMOVE: &[&str] = &[
     "chip-description-path=",
     "list-chips",
     "elf=",
+    "work-dir=",
     "disable-progressbars",
     "protocol=",
     "probe-index=",
@@ -185,6 +192,11 @@ fn main_try() -> Result<(), failure::Error> {
 
     // Remove all arguments that `cargo build` does not understand.
     remove_arguments(ARGUMENTS_TO_REMOVE, &mut args);
+
+    // Change the work dir if the user asked to do so
+    if let Some(work_dir) = opt.work_dir {
+        std::env::set_current_dir(work_dir)?;
+    }
 
     let path: PathBuf = if let Some(path) = opt.elf {
         path.into()


### PR DESCRIPTION
This adds an `--elf` argument to cargo-flash which can be used to flash targets from non rust environment or to debug cargo-flash from other directories.