### PR TITLE
fix cargo-metadata loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -199,9 +199,12 @@ fn main_try() -> Result<()> {
     logging::init(opt.log);
 
     // Load cargo manifest if available and parse out meta object
-    let meta = match Manifest::<Meta>::from_path_with_metadata("Cargo.toml") {
-        Ok(m) => m.package.map(|p| p.metadata).flatten(),
-        Err(_e) => None,
+    let meta = match std::fs::read("Cargo.toml") {
+        Ok(buffer) => match Manifest::<Meta>::from_slice_with_metadata(&buffer) {
+            Ok(m) => m.package.map(|p| p.metadata).flatten(),
+            Err(_e) => None,
+        },
+        Err(_) => None,
     };
 
     // If someone wants to list the connected probes, just do that and exit.


### PR DESCRIPTION
I had never seen this feature work and dug in. Not sure if its just my linux system or my Cargo toml, but I believe I found my problem. We don't need complete toml and complete_from_path call can fail and is implicit in from_path_with_metadata api call but not from_slice_with_metadata call.

Note this just fixes the existing implementation which is probably under developed. People are starting to use files other than Cargo.toml which will still be broken.

Also I think we should probably not pollute the top level metadata, and should probably be under package.metadata.cargo-flash or something.

Maybe for another day though.