### PR TITLE
add git commit hash to version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,13 @@ use probe_rs_cli_util::{
     argument_handling, build_artifact, logging, logging::Metadata, read_metadata,
 };
 
+const CARGO_NAME: &str = env!("CARGO_PKG_NAME");
+const CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_VERSION: &str = git_version::git_version!(fallback = "crates.io");
+
 lazy_static::lazy_static! {
     static ref METADATA: Arc<Mutex<Metadata>> = Arc::new(Mutex::new(Metadata {
-        release: env!("CARGO_PKG_VERSION").to_string(),
+        release: CARGO_VERSION.to_string(),
         chip: None,
         probe: None,
         speed: None,
@@ -36,6 +40,8 @@ lazy_static::lazy_static! {
 
 #[derive(Debug, StructOpt)]
 struct Opt {
+    #[structopt(short = "V", long = "version")]
+    pub version: bool,
     #[structopt(name = "chip", long = "chip")]
     chip: Option<String>,
     #[structopt(name = "chip description file path", long = "chip-description-path")]
@@ -198,6 +204,14 @@ fn main_try() -> Result<()> {
 
     // Get commandline options.
     let opt = Opt::from_iter(&args);
+
+    if opt.version {
+        println!(
+            "{} {}\ngit commit: {}",
+            CARGO_NAME, CARGO_VERSION, GIT_VERSION
+        );
+        return Ok(());
+    }
 
     logging::init(opt.log);
 


### PR DESCRIPTION
same as https://github.com/probe-rs/cargo-embed/pull/116

output:
```
cargo-flash 0.10.2
git commit: db4e2c3
```

I scrolled though matrix and saw this was still needed :) 

(this was not put into probe-rs-cli-util because it would then use the wrong commit hash iirc)