### PR TITLE
Improve CLI help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(bin_name = "cargo flash", after_help = CARGO_HELP_MESSAGE)]
 struct Opt {
     #[structopt(short = "V", long = "version")]
     pub version: bool,
@@ -119,26 +120,56 @@ struct Opt {
     #[structopt(long = "dry-run")]
     dry_run: bool,
 
-    // `cargo build` arguments
-    #[structopt(name = "binary", long = "bin")]
+    #[structopt(flatten)]
+    /// Arguments which are forwarded to 'cargo build'.
+    cargo_options: CargoOptions,
+}
+
+#[derive(StructOpt, Debug)]
+struct CargoOptions {
+    #[structopt(name = "binary", long = "bin", hidden = true)]
     bin: Option<String>,
-    #[structopt(name = "example", long = "example")]
+    #[structopt(name = "example", long = "example", hidden = true)]
     example: Option<String>,
-    #[structopt(name = "package", short = "p", long = "package")]
+    #[structopt(name = "package", short = "p", long = "package", hidden = true)]
     package: Option<String>,
-    #[structopt(name = "release", long = "release")]
+    #[structopt(name = "release", long = "release", hidden = true)]
     release: bool,
-    #[structopt(name = "target", long = "target")]
+    #[structopt(name = "target", long = "target", hidden = true)]
     target: Option<String>,
-    #[structopt(name = "PATH", long = "manifest-path", parse(from_os_str))]
+    #[structopt(
+        name = "PATH",
+        long = "manifest-path",
+        parse(from_os_str),
+        hidden = true
+    )]
     manifest_path: Option<PathBuf>,
-    #[structopt(long)]
+    #[structopt(long, hidden = true)]
     no_default_features: bool,
-    #[structopt(long)]
+    #[structopt(long, hidden = true)]
     all_features: bool,
-    #[structopt(long)]
+    #[structopt(long, hidden = true)]
     features: Vec<String>,
 }
+
+const CARGO_HELP_MESSAGE: &'static str = r#"
+CARGO BUILD OPTIONS:
+
+    The following options are forwarded to 'cargo build':
+
+        --bin
+        --example
+    -p, --package
+        --release
+        --target
+        --manifest-path
+        --no-default-features
+        --all-features
+        --features
+    
+    For example, if you run the command 'cargo flash --release', 
+    this means that 'cargo build --release' will be called.
+"#;
 
 const ARGUMENTS_TO_REMOVE: &[&str] = &[
     "chip=",


### PR DESCRIPTION
Separate the options which are forwarded to 'cargo build' from
the options which are used by cargo-flash itself. This should help with issue #162.

Also, the binary name in the help output is set to 'cargo flash',
to match how cargo-flash is usually used.

Previous help output:
```console
cargo-flash 0.10.2

USAGE:
    cargo-flash [FLAGS] [OPTIONS]

FLAGS:
        --all-features            
        --connect-under-reset     Use this flag to assert the nreset & ntrst pins during attaching the probe to the
                                  chip.
        --disable-progressbars    
        --dry-run                 
    -h, --help                    Prints help information
        --list-chips              
        --list-probes             Lists all the connected probes that can be seen.
                                  If udev rules or permissions are wrong, some probes might not be listed.
        --no-default-features     
        --release                 
        --reset-halt              Use this flag to reset and halt (instead of just a reset) the attached core after
                                  flashing the target.
        --restore-unwritten       Enable this flag to restore all bytes erased in the sector erase but not overwritten
                                  by any page.
    -V, --version                 

OPTIONS:
        --manifest-path <PATH>                                  
        --bin <binary>                                          
        --chip <chip>                                           
        --chip-description-path <chip description file path>    
        --work-dir <directory>
            The work directory from which cargo-flash should operate from.

        --elf <elf file>                                        The path to the ELF file to be flashed.
        --example <example>                                     
        --features <features>...                                
        --flash-layout <filename>
            Requests the flash builder to output the layout into the given file in SVG format.

        --log <level>
            Use this flag to set the log level.
            Default is `warning`. Possible choices are [error, warning, info, debug, trace].
    -p, --package <package>                                     
        --probe <probe-selector>
            Use this flag to select a specific probe in the list.
            Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one probe with the same VID:PID.
        --protocol <protocol>                                    [default: swd]
        --speed <speed>                                         The protocol speed in kHz.
        --target <target>                                       

```


New help output with this PR:

```console
cargo-flash 0.10.2

USAGE:
    cargo flash [FLAGS] [OPTIONS]

FLAGS:
        --connect-under-reset     Use this flag to assert the nreset & ntrst pins during attaching the probe to the
                                  chip.
        --disable-progressbars    
        --dry-run                 
    -h, --help                    Prints help information
        --list-chips              
        --list-probes             Lists all the connected probes that can be seen.
                                  If udev rules or permissions are wrong, some probes might not be listed.
        --reset-halt              Use this flag to reset and halt (instead of just a reset) the attached core after
                                  flashing the target.
        --restore-unwritten       Enable this flag to restore all bytes erased in the sector erase but not overwritten
                                  by any page.
    -V, --version                 

OPTIONS:
        --chip <chip>                                           
        --chip-description-path <chip description file path>    
        --work-dir <directory>
            The work directory from which cargo-flash should operate from.

        --elf <elf file>                                        The path to the ELF file to be flashed.
        --flash-layout <filename>
            Requests the flash builder to output the layout into the given file in SVG format.

        --log <level>
            Use this flag to set the log level.
            Default is `warning`. Possible choices are [error, warning, info, debug, trace].
        --probe <probe-selector>
            Use this flag to select a specific probe in the list.
            Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one probe with the same VID:PID.
        --protocol <protocol>                                    [default: swd]
        --speed <speed>                                         The protocol speed in kHz.


CARGO BUILD OPTIONS:

    The following options are forwarded to 'cargo build':

        --bin
        --example
    -p, --package
        --release
        --target
        --manifest-path
        --no-default-features
        --all-features
        --features
    
    For example, if you run the command 'cargo flash --release', 
    this means that 'cargo build --release' will be called.



```