### PR TITLE
Use clap to print version info.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +118,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,12 +175,14 @@ name = "cargo-flash"
 version = "0.12.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "bytesize",
  "colored",
  "dunce",
  "env_logger",
  "git-version",
  "lazy_static",
+ "predicates",
  "probe-rs",
  "probe-rs-cli-util",
  "thiserror",
@@ -301,10 +328,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -350,6 +395,15 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -664,6 +718,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1038,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "probe-rs"
@@ -1149,6 +1248,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1529,6 +1634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1846,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ anyhow = "1.0.57"
 bytesize = "1.1.0"
 thiserror = "1.0.31"
 dunce = "1.0.2"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "2.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use probe_rs_cli_util::logging::{ask_to_log_crash, capture_panic};
 
 use probe_rs_cli_util::{build_artifact, log, logging, logging::Metadata};
 
-const CARGO_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_VERSION: &str = git_version::git_version!(fallback = "crates.io");
 
@@ -75,17 +74,13 @@ fn main_try() -> Result<(), OperationError> {
     let matches = FlashOptions::into_app()
         .bin_name("cargo flash")
         .after_help(CargoOptions::help_message("cargo flash").as_str())
+        .version(CARGO_VERSION)
+        .long_version(&*format!(
+            "{}\ngit commit: {}",
+            CARGO_VERSION, GIT_VERSION
+        ))
         .get_matches_from(&args);
     let opt = FlashOptions::from_arg_matches(&matches)?;
-
-    // If we get the version option, print the current version immediately and exit.
-    if opt.version {
-        println!(
-            "{} {}\ngit commit: {}",
-            CARGO_NAME, CARGO_VERSION, GIT_VERSION
-        );
-        return Ok(());
-    }
 
     // Initialize the logger with the loglevel given on the commandline.
     logging::init(opt.log);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,29 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn query_long_version() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-flash")?;
+
+    cmd.arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::is_match(
+            "^cargo-flash \\S+\ngit commit: \\S+\\n$").unwrap());
+
+    Ok(())
+}
+
+#[test]
+fn query_short_version() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-flash")?;
+
+    cmd.arg("-V");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::is_match(
+            "^cargo-flash \\S+\\n$").unwrap());
+
+    Ok(())
+}


### PR DESCRIPTION
Clap provides https://docs.rs/clap/3.1.18/clap/struct.App.html#method.version which consumes any '-V' or '--version' flag, so the existing code doesn't seem to work.

The behaviour is changed slightly: '-V' now just outputs "cargo-flash 0.12.1" while '--version' also outputs the git commit. Previously, both flags would output the full version with git commit.

This commit also adds two simple integration tests that verifies this output.

---

Note that the version flag in [probe-rs-cli-utils](https://github.com/probe-rs/probe-rs/blob/master/probe-rs-cli-util/src/common_options.rs#L51) could probably be eliminated now.