### PR TITLE
Alwas show full source stack for errors.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
             #[cfg(not(feature = "sentry"))]
             log::info!("{:#?}", &METADATA.lock().unwrap());
 
-            // Ensure stderr is flushed before calling proces::exit,
+            // Ensure stderr is flushed before calling process::exit,
             // otherwise the process might panic, because it tries
             // to access stderr during shutdown.
             //


### PR DESCRIPTION
Instead of just displaying the top-level error, also print the source chain/stack to stderr (instead of just to the debug log or showing it when there were no hints.)

This was motivated by https://github.com/probe-rs/probe-rs/issues/76#issuecomment-678705319, where the helpful error message "The firmware on the probe is outdated" only gets printed to the debug log.

This PR now always prints the full chain to stderr, so the above error looks like this:
![image](https://user-images.githubusercontent.com/933300/171359964-63abb931-078a-4286-a426-b3e6b58bd3d0.png)

I'm not sure if this change is good/correct, as now the hint is wrong in this case. Also some other error messages get a bit repetitive/verbose:
![image](https://user-images.githubusercontent.com/933300/171360400-63933706-57ad-46db-90db-ab841d36a52e.png)

![image](https://user-images.githubusercontent.com/933300/171359869-08671e9a-3c6c-4dad-a584-a9270a2a3485.png)

And I haven't checked/reproduced all the other error messages, so it might be even more wrong in some other case.
The proper way to go would probably be to use [anyhow](https://crates.io/crates/anyhow) anyway, right? Which is actually already a dependency in the Cargo.toml but not used as far as I can tell ;)

(Related: https://blog.rust-lang.org/inside-rust/2021/07/01/What-the-error-handling-project-group-is-working-towards.html)