### PR TITLE
Match TargetResetFailed and TargetResetHaltFailed with operation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,7 @@ fn main_try() -> Result<(), OperationError> {
             core.reset_and_halt(std::time::Duration::from_millis(500))
                 .map_err(OperationError::TargetResetHaltFailed)?;
         } else {
-            core.reset()
-                .map_err(OperationError::TargetResetFailed)?;
+            core.reset().map_err(OperationError::TargetResetFailed)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,10 +175,10 @@ fn main_try() -> Result<(), OperationError> {
             .map_err(OperationError::AttachingToCoreFailed)?;
         if opt.reset_halt {
             core.reset_and_halt(std::time::Duration::from_millis(500))
-                .map_err(OperationError::TargetResetFailed)?;
+                .map_err(OperationError::TargetResetHaltFailed)?;
         } else {
             core.reset()
-                .map_err(OperationError::TargetResetHaltFailed)?;
+                .map_err(OperationError::TargetResetFailed)?;
         }
     }
 


### PR DESCRIPTION
Seems to be an old refactoring mistake where the wrong error variant was used with the wrong operation.